### PR TITLE
Kill route helpers, longer pause in smoketest [WIP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ save on client download time.
 Use this module instead of depending directly on React Router, and we'll worry about keeping all the version dependencies compatible and in-sync for you.
 
 ```js
-import { Router, Route } from 'react-easy-universal/route-helpers';
+import { Router, Route } from 'react-router';
 
 import createHome from 'shared/components/home';
 import createTestData from 'shared/components/test-data';

--- a/source/route-helpers/index.js
+++ b/source/route-helpers/index.js
@@ -1,3 +1,0 @@
-import { Router, Route } from 'react-router';
-import { connect } from 'react-redux';
-export { Router, Route, connect };

--- a/source/test/fixtures/routes.js
+++ b/source/test/fixtures/routes.js
@@ -1,4 +1,5 @@
-import { Router, Route, connect } from '../../route-helpers';
+import { Router, Route } from 'react-router';
+import { connect } from 'react-redux';
 
 // It expects a factory function that it can inject dependencies into.
 export default ({ React }) => {

--- a/source/test/functional/browser/smoketest.js
+++ b/source/test/functional/browser/smoketest.js
@@ -1,4 +1,4 @@
-const WAIT = 3000;
+const WAIT = 10000;
 const NODE_PORT = process.env.NODE_PORT || 3000;
 
 module.exports = {

--- a/source/test/functional/browser/smoketest.js
+++ b/source/test/functional/browser/smoketest.js
@@ -7,7 +7,7 @@ module.exports = {
       .url(`http://localhost:${NODE_PORT}/`)
       .waitForElementVisible('body', WAIT)
       .pause(WAIT)
-      .expect.element('body').text.to.contain('Client render').before(10000);
+      .expect.element('body').text.to.contain('Client render').before(10000)
       .end();
   }
 };

--- a/source/test/functional/browser/smoketest.js
+++ b/source/test/functional/browser/smoketest.js
@@ -6,7 +6,7 @@ module.exports = {
     browser
       .url(`http://localhost:${NODE_PORT}/`)
       .waitForElementVisible('body', WAIT)
-      .pause(800)
+      .pause(WAIT)
       .assert.containsText('body', 'Client render')
       .end();
   }

--- a/source/test/functional/browser/smoketest.js
+++ b/source/test/functional/browser/smoketest.js
@@ -1,4 +1,4 @@
-const WAIT = 10000;
+const WAIT = 3000;
 const NODE_PORT = process.env.NODE_PORT || 3000;
 
 module.exports = {
@@ -7,7 +7,7 @@ module.exports = {
       .url(`http://localhost:${NODE_PORT}/`)
       .waitForElementVisible('body', WAIT)
       .pause(WAIT)
-      .assert.containsText('body', 'Client render')
+      .expect.element('body').text.to.contain('Client render').before(10000);
       .end();
   }
 };


### PR DESCRIPTION
Trying to avoid race condition occurring in smoketest of #16 by adding more pause time to allow for completion of loading before testing client render.

[Awaiting CircleCI results, will close if unsuccessful]